### PR TITLE
Add Docker Compatibility 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+/vcpkg
+/vcpkg_installed
+/build
+/cmake-build-debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.31)
+cmake_minimum_required(VERSION 3.2)
 
 set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake"
         CACHE STRING "Vcpkg toolchain file")

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,8 @@ RUN echo '\
   }\n\
 }' > conf.json
 
+EXPOSE 3405
+
 # Log-Verzeichnis & Datei
 RUN mkdir -p log && touch log/default.log
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# Base image mit CMake und Build Tools
+FROM ubuntu:24.04
+
+# System-Dependencies installieren
+RUN apt-get update && apt-get install -y \
+    cmake \
+    g++ \
+    make \
+    git \
+    curl \
+    zip \
+    unzip \
+    tar \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Arbeitsverzeichnis
+WORKDIR /app
+
+# Projektdateien kopieren
+COPY . .
+
+RUN git clone https://github.com/microsoft/vcpkg && cd vcpkg && sh bootstrap-vcpkg.sh && ./vcpkg install fmt nlohmann-json spdlog boost-beast boost-asio && cd ..
+
+# Build-Verzeichnis anlegen und kompilieren
+RUN mkdir -p build && cd build && \
+    cmake .. && \
+    make
+
+# Konfigurationsdatei anlegen
+RUN echo '\
+{\n\
+  "general": {\n\
+    "communication": {\n\
+      "port": 4000\n\
+    },\n\
+    "logging": {\n\
+      "logLevel": 5\n\
+    }\n\
+  }\n\
+}' > conf.json
+
+# Log-Verzeichnis & Datei
+RUN mkdir -p log && touch log/default.log
+
+# Falls dein Binary z.B. "main" heißt

--- a/docs/COMPILING.md
+++ b/docs/COMPILING.md
@@ -1,131 +1,62 @@
-# Compiling Beams 
+# Building and Running Beams with Docker
 
+This document describes how to compile and run the Beams Engine using Docker.
 
-## For Compiling Beams on Windows you're going to need:
+## Requirements
 
-- [CMake](https://cmake.org/download/)
-- [Git](https://git-scm.com/downloads)
-- [Visual Studio 2022 Build Tools](https://visualstudio.microsoft.com/de/downloads/)
+- Docker
+- Git
 
-## For Compiling Beams on MacOs you're going to need:
-
-- [CMake]()
-- [Git (Included in XCode Command Line Tools)](#installing-needed-dependencies-macos)
-- [XCode Command Line Tools](#installing-needed-dependencies-macos)
-- [Homebrew](https://brew.sh/)
-
-### Installing needed Dependencies (MacOS)
-Installing XCode CLT (and Git)
-```bash
-    xcode-select --install
-```
-Installing Brew
-``` Bash
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-```
-Installing CMake:
-```bash
-    brew install cmake 
-```
-
-
-
-## For Compiling Beams on Linux you're going to need:
-
-
-- [CMake](https://cmake.org/download/)
-- [Git](https://git-scm.com/downloads)
-- [Build Essentials]() 
-
-### Installing Dependencies
-Ubuntu / Debian Based Distributions 
+## Clone the Repository
 
 ```bash
-    sudo apt install cmake git build-essential
-```
-Fedora / RHEL >8 / CentOS Stream
-
-```bash
-    sudo dnf groupinstall "Development Tools"
-    sudo dnf install cmake git 
-```
-
-Arch / Manjaro
-
-```bash
-    sudo pacman -S cmake git base-essentials
-```
-
-# Actually Compiling:
-
-
-## Windows
-
-Setting Up
-
-```shell
   git clone https://github.com/the0hdDev/beams-engine
   cd beams-engine
-  git clone https://github.com/microsoft/vcpkg
-  cd vcpkg
-  ./bootstrap-vcpkg.bat
-  ./vcpkg.exe install boost-beast boost-asio fmt spdlog
-  cd .. 
 ```
 
-```shell
-   mkdir build
-   cd build
-   cmake ..
-   cmake --build .. --config Release 
+## Build the Docker Image
+
+```bash
+  docker build -t beams-engine .
 ```
 
-## MacOS
+This will:
+- Clone and bootstrap vcpkg
+- Install required dependencies (boost-beast, boost-asio, fmt, spdlog)
+- Configure and build the project using CMake
+- Create a `conf.json` and a `log/default.log` inside the container
 
-Setting Up
+## Run the Container
 
-```shell
-  git clone https://github.com/the0hdDev/beams-engine
-  cd beams-engine
-  git clone https://github.com/microsoft/vcpkg
-  cd vcpkg
-  ./bootstrap-vcpkg.sh
-  ./vcpkg install boost-beast boost-asio fmt spdlog
-  cd .. 
+```bash
+  docker run -p 3405:3405 beams-engine
 ```
 
-```shell
-   mkdir build
-   cd build
-   cmake ..
-   cmake --build .. 
+This will start the compiled binary and expose port `3405` for WebSocket communication.
+
+## Mounting Configuration and Log Files (Optional)
+
+To use a custom configuration or persist log files, use volume mounts:
+
+```bash
+  docker run -p 3405:3405 \
+    -v $(pwd)/conf.json:/app/conf.json \
+    -v $(pwd)/log:/app/log \
+    beams-engine
 ```
 
-!!! There may be a Issue with uninstalled Config Flies. Please consult the [Issues Page](https://github.com/the0hdDev/beams-engine/issues).
+## Output
 
+- The compiled binary is located in `/app/build` inside the container.
+- Logs are written to `/app/log/default.log`.
 
-## Linux
+## Rebuilding After Code Changes
 
-Setting Up
-
-```shell
-  git clone https://github.com/the0hdDev/beams-engine
-  cd beams-engine
-  git clone https://github.com/microsoft/vcpkg
-  cd vcpkg
-  ./bootstrap-vcpkg.sh
-  ./vcpkg install boost-beast boost-asio fmt spdlog
-  cd .. 
+```bash
+  docker build --no-cache -t beams-engine .
 ```
 
-```shell
-   mkdir build
-   cd build
-   cmake ..
-   cmake --build .. 
-```
+## Troubleshooting
 
-!!! There may be a Issue with uninstalled Config Flies. Please consult the [Issues Page](https://github.com/the0hdDev/beams-engine/issues).
-
-
-## Now you should find a engine.exe / engine in the build directory
+If you encounter any issues, please refer to the Issues page:
+https://github.com/the0hdDev/beams-engine/issues


### PR DESCRIPTION
This pull request introduces Docker support for building and running the Beams Engine, updates the documentation to reflect this change, and makes minor adjustments to configuration files. The most important changes include adding a `Dockerfile`, updating the `.dockerignore` file, modifying the `CMakeLists.txt` file, and rewriting the build instructions in the documentation.

### Docker support:
* Added a `Dockerfile` to enable building and running the Beams Engine in a container. The file installs system dependencies, clones and bootstraps `vcpkg`, installs required libraries, builds the project using CMake, and sets up configuration and log files. It also exposes port `3405` for WebSocket communication.
* Updated `.dockerignore` to exclude build-related directories (`/vcpkg`, `/vcpkg_installed`, `/build`, `/cmake-build-debug`) from the Docker build context.

### Build configuration:
* Adjusted the minimum required CMake version in `CMakeLists.txt` from `3.31` to `3.2`, for broader compatibility.

### Documentation updates:
* Rewrote `docs/COMPILING.md` to focus on building and running the Beams Engine using Docker. Removed platform-specific instructions for manual compilation and added sections for building the Docker image, running the container, and troubleshooting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Docker support for building and running the application in a containerized environment.
  * Introduced a default configuration file and log setup within the Docker container.

* **Documentation**
  * Updated build instructions to focus on a streamlined Docker-based workflow, replacing manual platform-specific steps.

* **Chores**
  * Added a .dockerignore file to optimize Docker builds by excluding unnecessary directories.
  * Lowered the minimum required CMake version for broader compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->